### PR TITLE
Promote next to main: trigger fixes + CI workflow (1.5.8-rc.2)

### DIFF
--- a/.github/workflows/build-firmware.yml
+++ b/.github/workflows/build-firmware.yml
@@ -5,8 +5,8 @@ on:
   push:
     branches: [ "main", "next" ]
     tags:
-      - "*.*.*"
-      - "pre-*"
+      - "[0-9]+.[0-9]+.[0-9]+"
+      - "[0-9]+.[0-9]+.[0-9]+-rc.[0-9]+"
 
 permissions:
   contents: write 
@@ -55,10 +55,13 @@ jobs:
         run: |
           TAG_NAME="${GITHUB_REF_NAME}"
 
-          if [[ "$TAG_NAME" == pre-* ]] || [[ "$TAG_NAME" == *"-rc"* ]] || [[ "$TAG_NAME" == *"-beta"* ]]; then
+          if [[ "$TAG_NAME" =~ ^[0-9]+\.[0-9]+\.[0-9]+-rc\.[0-9]+$ ]]; then
             echo "prerelease=true" >> $GITHUB_OUTPUT
-          else
+          elif [[ "$TAG_NAME" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
             echo "prerelease=false" >> $GITHUB_OUTPUT
+          else
+            echo "Unrecognized tag format: $TAG_NAME" >&2
+            exit 1
           fi
           
       - name: Capture build metadata

--- a/.github/workflows/build-firmware.yml
+++ b/.github/workflows/build-firmware.yml
@@ -52,6 +52,7 @@ jobs:
       # ---------------------------
       - name: Detect release type
         id: reltype
+        if: startsWith(github.ref, 'refs/tags/')
         run: |
           TAG_NAME="${GITHUB_REF_NAME}"
 

--- a/.github/workflows/build-firmware.yml
+++ b/.github/workflows/build-firmware.yml
@@ -5,11 +5,11 @@ on:
   push:
     branches: [ "main", "next" ]
     tags:
-      - "[0-9]+.[0-9]+.[0-9]+"
-      - "[0-9]+.[0-9]+.[0-9]+-rc.[0-9]+"
+      - "*.*.*"
+      - "*.*.*-rc.*"
 
 permissions:
-  contents: write 
+  contents: write
 
 jobs:
   build:
@@ -19,26 +19,20 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          fetch-depth: 0        # full history so git-describe works
-          fetch-tags: true       # ensure all tags are present
+          fetch-depth: 0
+          fetch-tags: true
 
-      # ---------------------------
-      # Build Firmware
-      # ---------------------------
       - name: Pull build image
-        run: docker pull ghcr.io/openwaterhealth/stm32-build-env:latest 
+        run: docker pull ghcr.io/openwaterhealth/stm32-build-env:latest
+
       - name: Build inside container
         run: |
           docker run --rm \
             -v "$GITHUB_WORKSPACE":/workspace \
             -w /workspace \
-            --workdir /workspace \
             ghcr.io/openwaterhealth/stm32-build-env:latest \
             bash -lc "git config --global --add safe.directory /workspace && cmake --preset Debug && cmake --build build/Debug --config Debug --target all -j 10"
 
-      # ---------------------------
-      # Upload Firmware
-      # ---------------------------
       - name: Upload firmware artifact
         uses: actions/upload-artifact@v4
         with:
@@ -47,9 +41,6 @@ jobs:
             build/Debug/*.hex
             build/Debug/*.bin
 
-      # ---------------------------
-      # Create GitHub Release (tags only)
-      # ---------------------------
       - name: Detect release type
         id: reltype
         if: startsWith(github.ref, 'refs/tags/')
@@ -57,19 +48,19 @@ jobs:
           TAG_NAME="${GITHUB_REF_NAME}"
 
           if [[ "$TAG_NAME" =~ ^[0-9]+\.[0-9]+\.[0-9]+-rc\.[0-9]+$ ]]; then
-            echo "prerelease=true" >> $GITHUB_OUTPUT
+            echo "prerelease=true" >> "$GITHUB_OUTPUT"
           elif [[ "$TAG_NAME" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            echo "prerelease=false" >> $GITHUB_OUTPUT
+            echo "prerelease=false" >> "$GITHUB_OUTPUT"
           else
             echo "Unrecognized tag format: $TAG_NAME" >&2
             exit 1
           fi
-          
+
       - name: Capture build metadata
         id: buildmeta
         run: |
-          echo "sha=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
-          echo "datetime=$(date -u '+%Y-%m-%d %H:%M:%S UTC')" >> $GITHUB_OUTPUT
+          echo "sha=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
+          echo "datetime=$(date -u '+%Y-%m-%d %H:%M:%S UTC')" >> "$GITHUB_OUTPUT"
 
       - name: Generate release notes
         if: startsWith(github.ref, 'refs/tags/')
@@ -81,14 +72,15 @@ jobs:
             echo "" >> notes.md
           fi
 
-          PREV_TAG=$(git tag --sort=-creatordate | sed -n '2p')
+          PREV_TAG=$(git tag --sort=-creatordate | grep -v "^${GITHUB_REF_NAME}$" | head -n 1)
 
           if [ -z "$PREV_TAG" ]; then
             git log --pretty=format:"- %s" >> notes.md
           else
-            git log ${PREV_TAG}..HEAD --pretty=format:"- %s" >> notes.md
+            git log "$PREV_TAG"..HEAD --pretty=format:"- %s" >> notes.md
           fi
 
+          echo "" >> notes.md
           echo "" >> notes.md
           echo "---" >> notes.md
           echo "**Build SHA:** \`${{ steps.buildmeta.outputs.sha }}\`" >> notes.md
@@ -98,11 +90,12 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/')
         uses: softprops/action-gh-release@v2
         with:
-          prerelease: ${{ steps.reltype.outputs.prerelease }}
-          allow_updates: ${{ steps.reltype.outputs.prerelease }}
-          replace_existing_artifacts: ${{ steps.reltype.outputs.prerelease }}
+          tag_name: ${{ github.ref_name }}
           name: ${{ github.ref_name }}
+          prerelease: ${{ steps.reltype.outputs.prerelease }}
           body_path: notes.md
+          overwrite_files: true
+          make_latest: ${{ steps.reltype.outputs.prerelease == 'false' }}
           files: |
             build/Debug/*.hex
             build/Debug/*.bin

--- a/Core/Inc/trigger.h
+++ b/Core/Inc/trigger.h
@@ -18,7 +18,7 @@
 #define NUM_DARK_FRAMES_AT_START 10
 
 typedef struct {
-    uint32_t frequencyHz;        // Trigger frequency in Hz 1 - 100
+    float    frequencyHz;        // Trigger frequency in Hz 1.00 - 100.00 (2-decimal precision)
     uint32_t triggerPulseWidthUsec;     // Pulse width in microseconds max determined by freq
     uint32_t laserPulseDelayUsec;     // Pulse width in microseconds max based on selected freq
     uint32_t laserPulseWidthUsec;     // Pulse width in microseconds max based on selected freq
@@ -39,6 +39,7 @@ uint32_t get_lsync_pulse_count(void);
 uint32_t get_fsync_pulse_count(void);
 void Trigger_Safety_Disconnect(void);
 void Trigger_Safety_Clear(void);
+void Trigger_PrintConfig(const Trigger_Config_t *config);
 
 void FSYNC_DelayElapsedCallback(TIM_HandleTypeDef *htim);
 void LSYNC_DelayElapsedCallback(TIM_HandleTypeDef *htim);

--- a/Core/Src/main.c
+++ b/Core/Src/main.c
@@ -461,7 +461,7 @@ int main(void)
   
   // config trigger timers
   Trigger_Config_t triggerSetup;
-  triggerSetup.frequencyHz = 40;
+  triggerSetup.frequencyHz = 40.0f;
   triggerSetup.triggerPulseWidthUsec = 1000;
   triggerSetup.laserPulseDelayUsec = 250;
   triggerSetup.laserPulseWidthUsec = 1000;

--- a/Core/Src/trigger.c
+++ b/Core/Src/trigger.c
@@ -118,20 +118,18 @@ static void trigger_GetConfigJSON(char *jsonString, size_t max_length)
 
 static void updateTimerDataFromPeripheral()
 {
-	 // Assuming you have the timer configuration and status
 	 uint32_t preScaler = FSYNC_TIMER.Instance->PSC;
 	 uint32_t timerClockFrequency = HAL_RCC_GetPCLK1Freq() / (preScaler + 1);
 	 uint32_t TIM_ARR = FSYNC_TIMER.Instance->ARR;
 	 uint32_t TIM_CCRx = HAL_TIM_ReadCapturedValue(&FSYNC_TIMER, FSYNC_TIMER_CHAN);
 	 trigger_config.frequencyHz = (float)timerClockFrequency / (float)(TIM_ARR + 1);
-	 trigger_config.triggerPulseWidthUsec = ((TIM_CCRx * 100000) / timerClockFrequency) * 10; // Set the pulse width as needed
+	 trigger_config.triggerPulseWidthUsec = ((TIM_CCRx * 100000) / timerClockFrequency) * 10;
 
-	 uint32_t LASER_ARR = LASER_TIMER.Instance->ARR;
-	 uint32_t LASER_CCRx = HAL_TIM_ReadCapturedValue(&LASER_TIMER, FSYNC_TIMER_CHAN);
-	 trigger_config.laserPulseDelayUsec = LASER_CCRx;
-	 trigger_config.laserPulseWidthUsec = LASER_ARR - LASER_CCRx + 1; // Set the pulse width as needed
+	 // LASER_TIMER ARR/CCR1 alternate between short_lsync and long_lsync slots,
+	 // both of which are composites of laserPulseDelayUsec + LaserPulseSkipDelayUsec.
+	 // They can't be unambiguously reversed into the source fields, so trust the
+	 // in-RAM values that Trigger_SetConfig already stored.
 
-	 // Check the timer status to determine if it's running
 	 trigger_config.TriggerStatus = TIM_CHANNEL_STATE_GET(&FSYNC_TIMER, FSYNC_TIMER_CHAN);
 }
 

--- a/Core/Src/trigger.c
+++ b/Core/Src/trigger.c
@@ -57,8 +57,7 @@ static int jsonToTriggerConfigData(const char *jsonString, Trigger_Config_t* new
     }
 
     for (i = 1; i < r; i++) {
-        if (jsoneq(jsonString, &t[i], "TriggerFrequencyHz") == 0 ||
-            jsoneq(jsonString, &t[i], "frequencyHz") == 0) {
+        if (jsoneq(jsonString, &t[i], "TriggerFrequencyHz") == 0) {
             newConfig->frequencyHz = strtof(jsonString + t[i + 1].start, NULL);
             i++;
         } else if (jsoneq(jsonString, &t[i], "TriggerPulseWidthUsec") == 0) {

--- a/Core/Src/trigger.c
+++ b/Core/Src/trigger.c
@@ -15,7 +15,7 @@
 
 
 // setup default
-Trigger_Config_t trigger_config = { 40, 1000, 250, 1000 };
+Trigger_Config_t trigger_config = { 40.0f, 1000, 250, 1000 };
 
 volatile uint8_t _usb_trigger_interlock = 0;
 volatile uint8_t _safety_trigger_interlock = 0;
@@ -57,8 +57,9 @@ static int jsonToTriggerConfigData(const char *jsonString, Trigger_Config_t* new
     }
 
     for (i = 1; i < r; i++) {
-        if (jsoneq(jsonString, &t[i], "TriggerFrequencyHz") == 0) {
-            newConfig->frequencyHz = strtoul(jsonString + t[i + 1].start, NULL, 10);
+        if (jsoneq(jsonString, &t[i], "TriggerFrequencyHz") == 0 ||
+            jsoneq(jsonString, &t[i], "frequencyHz") == 0) {
+            newConfig->frequencyHz = strtof(jsonString + t[i + 1].start, NULL);
             i++;
         } else if (jsoneq(jsonString, &t[i], "TriggerPulseWidthUsec") == 0) {
             newConfig->triggerPulseWidthUsec = strtoul(jsonString + t[i + 1].start, NULL, 10);
@@ -94,7 +95,7 @@ static void trigger_GetConfigJSON(char *jsonString, size_t max_length)
     memset(jsonString, 0, max_length);
     snprintf(jsonString, max_length,
              "{"
-             "\"TriggerFrequencyHz\": %lu,"
+             "\"TriggerFrequencyHz\": %.2f,"
              "\"TriggerPulseWidthUsec\": %lu,"
              "\"LaserPulseDelayUsec\": %lu,"
              "\"LaserPulseWidthUsec\": %lu,"
@@ -104,7 +105,7 @@ static void trigger_GetConfigJSON(char *jsonString, size_t max_length)
              "\"EnableTaTrigger\": %s,"
              "\"TriggerStatus\": %lu"
              "}",
-             trigger_config.frequencyHz,
+             (double)trigger_config.frequencyHz,
              trigger_config.triggerPulseWidthUsec,
              trigger_config.laserPulseDelayUsec,
              trigger_config.laserPulseWidthUsec,
@@ -122,7 +123,7 @@ static void updateTimerDataFromPeripheral()
 	 uint32_t timerClockFrequency = HAL_RCC_GetPCLK1Freq() / (preScaler + 1);
 	 uint32_t TIM_ARR = FSYNC_TIMER.Instance->ARR;
 	 uint32_t TIM_CCRx = HAL_TIM_ReadCapturedValue(&FSYNC_TIMER, FSYNC_TIMER_CHAN);
-	 trigger_config.frequencyHz = timerClockFrequency / (TIM_ARR + 1);
+	 trigger_config.frequencyHz = (float)timerClockFrequency / (float)(TIM_ARR + 1);
 	 trigger_config.triggerPulseWidthUsec = ((TIM_CCRx * 100000) / timerClockFrequency) * 10; // Set the pulse width as needed
 
 	 uint32_t LASER_ARR = LASER_TIMER.Instance->ARR;
@@ -168,7 +169,7 @@ HAL_StatusTypeDef Trigger_SetConfig(const Trigger_Config_t *config) {
     }
 
     // Add range checks for the configuration parameters
-    if (config->frequencyHz == 0 || config->triggerPulseWidthUsec == 0 || config->frequencyHz > 100) {
+    if (config->frequencyHz < 1.0f || config->triggerPulseWidthUsec == 0 || config->frequencyHz > 100.0f) {
         return HAL_ERROR; // Invalid configuration values
     }
 
@@ -193,7 +194,7 @@ HAL_StatusTypeDef Trigger_SetConfig(const Trigger_Config_t *config) {
     FSYNC_TIMER.Instance->PSC = fsync_prescaler;
 
     // Calculate ARR and CCR1
-    uint32_t arr_ticks = (1000000UL / config->frequencyHz); // period in µs
+    uint32_t arr_ticks = (uint32_t)(1000000.0f / config->frequencyHz + 0.5f); // period in µs, rounded to nearest tick
     if (config->triggerPulseWidthUsec >= arr_ticks) {
         return HAL_ERROR; // Pulse width too long
     }
@@ -281,13 +282,15 @@ HAL_StatusTypeDef Trigger_SetConfigFromJSON(char *jsonString, size_t str_len)
 	uint8_t tempArr[255] = {0};
 	bool ret = HAL_OK;
 
-	Trigger_Config_t new_config;
-    new_config.LaserPulseSkipDelayUsec = 1800; //
+	// Seed from current config so any field absent from JSON keeps its current value
+	Trigger_Config_t new_config = trigger_config;
     // Copy the JSON string to tempArr
     memcpy((char *)tempArr, (char *)jsonString, str_len);
+    // printf("Trigger_SetConfigFromJSON: %s\r\n", (char *)tempArr);
 
 	if (jsonToTriggerConfigData((const char *)tempArr, &new_config) == 0)
 	{
+        Trigger_PrintConfig((const Trigger_Config_t*)&new_config);
 		Trigger_SetConfig(&new_config);
 		ret = HAL_OK;
 	}
@@ -314,6 +317,21 @@ uint32_t get_lsync_pulse_count(void)
 uint32_t get_fsync_pulse_count(void)
 {
 	return fsync_counter;
+}
+
+void Trigger_PrintConfig(const Trigger_Config_t *config)
+{
+    if (config == NULL) { return; }
+    printf("Trigger_Config_t:\r\n");
+    printf("  frequencyHz:           %.2f\r\n", (double)config->frequencyHz);
+    printf("  triggerPulseWidthUsec: %lu\r\n", config->triggerPulseWidthUsec);
+    printf("  laserPulseDelayUsec:   %lu\r\n", config->laserPulseDelayUsec);
+    printf("  laserPulseWidthUsec:   %lu\r\n", config->laserPulseWidthUsec);
+    printf("  LaserPulseSkipInterval:%lu\r\n", config->LaserPulseSkipInterval);
+    printf("  LaserPulseSkipDelayUs: %lu\r\n", config->LaserPulseSkipDelayUsec);
+    printf("  EnableSyncOut:         %s\r\n", config->EnableSyncOut  ? "true" : "false");
+    printf("  EnableTaTrigger:       %s\r\n", config->EnableTaTrigger? "true" : "false");
+    printf("  TriggerStatus:         %lu\r\n", config->TriggerStatus);
 }
 
 void FSYNC_DelayElapsedCallback(TIM_HandleTypeDef *htim)


### PR DESCRIPTION
## Summary

Promotes `next` to `main`. Brings in:

1. **More granular trigger control** (`2d28b3e`) — `frequencyHz` widened to `float` for sub-Hz precision, range check tightened to `[1.0, 100.0]`, and `Trigger_SetConfigFromJSON` now seeds `new_config` from the current `trigger_config` so absent JSON fields keep their values rather than picking up stack garbage.

2. **Trigger laser-readback fix** (`9ec5d06`) — `updateTimerDataFromPeripheral` no longer overwrites `laserPulseDelayUsec`/`laserPulseWidthUsec` from `LASER_TIMER` registers. Both LASER_TIMER ARR/CCR1 alternate between short_lsync and long_lsync slots at runtime, encoding composites of `laserPulseDelayUsec + LaserPulseSkipDelayUsec`; they can't be unambiguously reversed into the source fields. The in-RAM `trigger_config` (set by `Trigger_SetConfig`) is now the source of truth for those fields. **Visible host symptom this fixes:** sending `LaserPulseDelayUsec: 100` used to come back as `1900` in the SET response JSON.

3. **JSON key consistency** (`bcdcf7d`) — drops the camelCase `frequencyHz` alias added in 2d28b3e. PascalCase `TriggerFrequencyHz` is the sole accepted key, matching all other JSON fields in the trigger config and the firmware's GET response.

4. **CI workflow** (`bf4e34e`, `f833ee0`, `048ea0a`) — auto-builds firmware on push to main/next and on tag push (`X.Y.Z` and `X.Y.Z-rc.N`); creates a GitHub Release with `motion-console-fw.bin`/`.hex` attached on tag pushes.

## Tag

`1.5.8-rc.2` already cut against this exact tip and validated on hardware (Ethan ran `test_console_trigger.py` against it; trigger config round-trips correctly, `start_trigger`/`stop_trigger` work, FSYNC pulse count matches configured rate). Release with the bin attached is up at https://github.com/OpenwaterHealth/openmotion-console-fw/releases/tag/1.5.8-rc.2

After this merges, suggest cutting `1.5.8` (non-rc) on main as the production tag.

## Known follow-ups (not blocking this merge)

- `Trigger_SetConfig` doesn't auto-restart the trigger if it was running — caller must re-issue `start_trigger` after a SET. Possibly intentional, sharp edge worth documenting.
- Validation gaps: only `frequencyHz` and `triggerPulseWidthUsec` are range-checked. `LaserPulseSkipInterval`, `LaserPulseSkipDelayUsec`, `laserPulseDelayUsec`, `laserPulseWidthUsec` accept any uint32.
- `Trigger_SetConfigFromJSON`: `tempArr[255]` with `memcpy(tempArr, jsonString, str_len)` has no length check (UART layer caps payloads, but a defensive check would be cheap).
- `trigger.c:18` static initializer `Trigger_Config_t trigger_config = { 40.0f, 1000, 250, 1000 };` only sets the first 4 fields. After this PR, `LaserPulseSkipDelayUsec` defaults to 0 (was previously masked by a `=1800` line in `Trigger_SetConfigFromJSON`). If the dark-frame slot matters operationally, add an explicit init.

## Test plan

- [x] CI builds clean on `1.5.8-rc.2` and produces `motion-console-fw.bin`
- [x] Hardware: `test_console_trigger.py` round-trips trigger config correctly against the rc.2 binary
- [ ] Reviewer to confirm any sensor or scan-orchestration side effects from the float-typed `frequencyHz`

🤖 Generated with [Claude Code](https://claude.com/claude-code)