### PR TITLE
feat(fw): per-frame PDC capture pipeline

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -118,6 +118,8 @@ target_sources(${CMAKE_PROJECT_NAME} PRIVATE
     Core/Src/motion_config.c
     Core/Src/fpga_register_map.c
     Core/Src/utils.c
+    Core/Src/pdc_buffer.c
+    Core/Src/pdc_poll.c
 )
 
 # Add include paths

--- a/CommandHandling.md
+++ b/CommandHandling.md
@@ -140,6 +140,7 @@ Examples include:
 | `OW_CTRL_TEC_STATUS` | Read TEC controller status and faults   |
 | `OW_CTRL_BOARDID`    | Read board identification information   |
 | `OW_CTRL_PDUMON`     | Read power distribution monitoring data |
+| `OW_CTRL_GET_PDC_BUFFER` | Drain up to N per-frame PDC samples from the SRAM ring buffer. Request payload: 1 byte = max_samples (1..64). Response: 2-byte LE drop counter + 1-byte sample count + N × 7-byte packed `{u32 frame_idx, u16 pdc_raw, u8 flags}`. `flags` bit 0 = `dark_slot`. |
 
 Each command defines its own payload format and response payload.
 

--- a/Core/Inc/common.h
+++ b/Core/Inc/common.h
@@ -110,6 +110,7 @@ typedef enum {
 	OW_CTRL_TEC_STATUS = 0x22,
 	OW_CTRL_BOARDID = 0x23,
 	OW_CTRL_PDUMON = 0x24,
+	OW_CTRL_GET_PDC_BUFFER = 0x25,
 } MotionControllerCommands;
 
 typedef enum {

--- a/Core/Inc/pdc_buffer.h
+++ b/Core/Inc/pdc_buffer.h
@@ -1,0 +1,25 @@
+/* Core/Inc/pdc_buffer.h */
+#ifndef INC_PDC_BUFFER_H_
+#define INC_PDC_BUFFER_H_
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <stddef.h>
+
+#define PDC_BUFFER_CAPACITY 256
+
+typedef struct __attribute__((packed)) {
+    uint32_t frame_idx;
+    uint16_t pdc_raw;
+    uint8_t  flags;   /* bit 0 = dark_slot */
+} pdc_sample_t;
+
+#define PDC_FLAG_DARK_SLOT (1u << 0)
+
+void     pdc_buffer_reset(void);
+bool     pdc_buffer_push(const pdc_sample_t *sample);  /* drop-oldest on overflow, returns true if a drop occurred */
+size_t   pdc_buffer_drain(pdc_sample_t *out, size_t max_samples);
+uint16_t pdc_buffer_dropped_since_last_drain(void);
+size_t   pdc_buffer_count(void);
+
+#endif

--- a/Core/Inc/pdc_buffer.h
+++ b/Core/Inc/pdc_buffer.h
@@ -22,4 +22,8 @@ size_t   pdc_buffer_drain(pdc_sample_t *out, size_t max_samples);
 uint16_t pdc_buffer_dropped_since_last_drain(void);
 size_t   pdc_buffer_count(void);
 
+/* Add external drops (e.g. producer-side ISR overflow) to the pending counter
+ * so they surface through the same drained-drop-count channel. */
+void     pdc_buffer_account_drops(uint16_t n);
+
 #endif

--- a/Core/Inc/pdc_poll.h
+++ b/Core/Inc/pdc_poll.h
@@ -1,0 +1,13 @@
+/* Core/Inc/pdc_poll.h */
+#ifndef INC_PDC_POLL_H_
+#define INC_PDC_POLL_H_
+
+#include <stdint.h>
+
+void pdc_poll_init(void);
+/* Call from the main loop. Performs the I2C read of the safety FPGA peak-power
+ * register and pushes a pdc_sample_t to the buffer when one is pending and the
+ * post-pulse settling time has elapsed. Non-blocking otherwise. */
+void pdc_poll_tick(void);
+
+#endif

--- a/Core/Inc/trigger.h
+++ b/Core/Inc/trigger.h
@@ -48,6 +48,7 @@ void FSYNC_PeriodElapsedCallback(TIM_HandleTypeDef *htim);
 void LSYNC_PeriodElapsedCallback(TIM_HandleTypeDef *htim);
 bool get_current_slot_is_dark(void);
 bool consume_pdc_sample_pending(bool *out_dark_slot, uint32_t *out_frame_idx);
+uint16_t consume_pdc_pending_overwrites(void);
 
 extern Trigger_Config_t trigger_config;
 

--- a/Core/Inc/trigger.h
+++ b/Core/Inc/trigger.h
@@ -45,6 +45,9 @@ void FSYNC_DelayElapsedCallback(TIM_HandleTypeDef *htim);
 void LSYNC_DelayElapsedCallback(TIM_HandleTypeDef *htim);
 
 void FSYNC_PeriodElapsedCallback(TIM_HandleTypeDef *htim);
+void LSYNC_PeriodElapsedCallback(TIM_HandleTypeDef *htim);
+bool get_current_slot_is_dark(void);
+bool consume_pdc_sample_pending(bool *out_dark_slot, uint32_t *out_frame_idx);
 
 extern Trigger_Config_t trigger_config;
 

--- a/Core/Src/if_commands.c
+++ b/Core/Src/if_commands.c
@@ -20,6 +20,7 @@
 #include "led_driver.h"
 #include "motion_config.h"
 #include "msg_queue.h"
+#include "pdc_buffer.h"
 
 #include <string.h>
 
@@ -497,6 +498,29 @@ static _Bool process_controller_command(UartPacket *uartResp, UartPacket *cmd)
         uartResp->data_len = (uint16_t)sizeof(pdu_frame);
         uartResp->data = pdu_frame.bytes;
         break;
+    case OW_CTRL_GET_PDC_BUFFER: {
+        uartResp->command = OW_CTRL_GET_PDC_BUFFER;
+        uartResp->addr = cmd->addr;
+        uartResp->reserved = cmd->reserved;
+
+        /* Request payload: 1 byte = max_samples (clamped to 64). */
+        uint8_t requested = (cmd->data_len >= 1) ? cmd->data[0] : 64;
+        if (requested == 0 || requested > 64) requested = 64;
+
+        /* Response layout: [dropped:u16 LE][count:u8][count * sizeof(pdc_sample_t)] */
+        static pdc_sample_t drained[64];
+        size_t n = pdc_buffer_drain(drained, requested);
+        uint16_t dropped = pdc_buffer_dropped_since_last_drain();
+
+        static uint8_t resp[3 + 64 * sizeof(pdc_sample_t)];
+        resp[0] = (uint8_t)(dropped & 0xFF);
+        resp[1] = (uint8_t)((dropped >> 8) & 0xFF);
+        resp[2] = (uint8_t)n;
+        memcpy(&resp[3], drained, n * sizeof(pdc_sample_t));
+
+        uartResp->data_len = (uint16_t)(3 + n * sizeof(pdc_sample_t));
+        uartResp->data = resp;
+    } break;
     default:
         uartResp->data_len = 0;
         uartResp->packet_type = OW_UNKNOWN;

--- a/Core/Src/main.c
+++ b/Core/Src/main.c
@@ -28,6 +28,7 @@
 #include "usbd_cdc_if.h"
 #include "uart_comms.h"
 #include "trigger.h"
+#include "pdc_poll.h"
 #include "led_driver.h"
 #include "tca9548a.h"
 #include "pca9535.h"
@@ -564,6 +565,7 @@ int main(void)
   HAL_Delay(100);
 
   comms_init();
+  pdc_poll_init();
   /* Start TIM4 interrupt for telemetry polling (250 ms) */
   HAL_TIM_Base_Start_IT(&htim4);
 
@@ -579,6 +581,7 @@ int main(void)
     comms_process();
     telemetry_poll();
     usb_recovery_task();
+    pdc_poll_tick();
     HAL_Delay(1);
   }
   /* USER CODE END 3 */
@@ -1736,6 +1739,9 @@ void HAL_TIM_PeriodElapsedCallback(TIM_HandleTypeDef *htim)
   }
   if (htim->Instance == FSYNC_TIMER.Instance) {
     FSYNC_PeriodElapsedCallback(htim);
+  }
+  if (htim->Instance == LASER_TIMER.Instance) {
+    LSYNC_PeriodElapsedCallback(htim);
   }
 
   if (htim->Instance == TIM12) {

--- a/Core/Src/pdc_buffer.c
+++ b/Core/Src/pdc_buffer.c
@@ -1,0 +1,49 @@
+/* Core/Src/pdc_buffer.c */
+#include "pdc_buffer.h"
+#include <string.h>
+
+static pdc_sample_t s_buf[PDC_BUFFER_CAPACITY];
+static volatile uint16_t s_head;        /* write idx */
+static volatile uint16_t s_tail;        /* read idx */
+static volatile uint16_t s_count;
+static volatile uint16_t s_dropped_pending;  /* drops since last drain */
+
+void pdc_buffer_reset(void) {
+    s_head = 0; s_tail = 0; s_count = 0; s_dropped_pending = 0;
+    memset(s_buf, 0, sizeof(s_buf));
+}
+
+bool pdc_buffer_push(const pdc_sample_t *sample) {
+    bool dropped = false;
+    if (s_count == PDC_BUFFER_CAPACITY) {
+        /* drop oldest */
+        s_tail = (uint16_t)((s_tail + 1) % PDC_BUFFER_CAPACITY);
+        s_count--;
+        s_dropped_pending++;
+        dropped = true;
+    }
+    s_buf[s_head] = *sample;
+    s_head = (uint16_t)((s_head + 1) % PDC_BUFFER_CAPACITY);
+    s_count++;
+    return dropped;
+}
+
+size_t pdc_buffer_drain(pdc_sample_t *out, size_t max_samples) {
+    size_t n = 0;
+    while (n < max_samples && s_count > 0) {
+        out[n++] = s_buf[s_tail];
+        s_tail = (uint16_t)((s_tail + 1) % PDC_BUFFER_CAPACITY);
+        s_count--;
+    }
+    return n;
+}
+
+uint16_t pdc_buffer_dropped_since_last_drain(void) {
+    uint16_t d = s_dropped_pending;
+    s_dropped_pending = 0;
+    return d;
+}
+
+size_t pdc_buffer_count(void) {
+    return s_count;
+}

--- a/Core/Src/pdc_buffer.c
+++ b/Core/Src/pdc_buffer.c
@@ -47,3 +47,7 @@ uint16_t pdc_buffer_dropped_since_last_drain(void) {
 size_t pdc_buffer_count(void) {
     return s_count;
 }
+
+void pdc_buffer_account_drops(uint16_t n) {
+    s_dropped_pending = (uint16_t)(s_dropped_pending + n);
+}

--- a/Core/Src/pdc_poll.c
+++ b/Core/Src/pdc_poll.c
@@ -27,6 +27,13 @@ void pdc_poll_init(void) {
 }
 
 void pdc_poll_tick(void) {
+    /* Account for any ISR-side queue overwrites so they surface in the same
+     * dropped-count channel as ring-buffer drops. */
+    uint16_t ow = consume_pdc_pending_overwrites();
+    if (ow > 0) {
+        pdc_buffer_account_drops(ow);
+    }
+
     /* Pick up any new pending sample from the LSYNC ISR. */
     if (!s_have_pending) {
         bool d; uint32_t f;

--- a/Core/Src/pdc_poll.c
+++ b/Core/Src/pdc_poll.c
@@ -1,0 +1,67 @@
+/* Core/Src/pdc_poll.c */
+#include "pdc_poll.h"
+#include "pdc_buffer.h"
+#include "trigger.h"
+#include "tca9548a.h"
+#include "stm32h7xx_hal.h"
+#include <stdbool.h>
+#include <stdio.h>
+
+#define PDC_MUX_INDEX   1
+#define PDC_CHANNEL     7
+#define PDC_I2C_ADDR    0x41
+#define PDC_REG         0x1C
+#define PDC_BYTES       2
+#define PDC_SETTLE_MS   1   /* FPGA averaging window after laser pulse falls */
+
+static uint32_t s_pending_since_tick = 0;
+static bool     s_have_pending = false;
+static bool     s_dark_slot = false;
+static uint32_t s_frame_idx = 0;
+static uint32_t s_fail_count = 0;
+
+void pdc_poll_init(void) {
+    s_pending_since_tick = 0;
+    s_have_pending = false;
+    s_fail_count = 0;
+}
+
+void pdc_poll_tick(void) {
+    /* Pick up any new pending sample from the LSYNC ISR. */
+    if (!s_have_pending) {
+        bool d; uint32_t f;
+        if (consume_pdc_sample_pending(&d, &f)) {
+            s_have_pending = true;
+            s_dark_slot = d;
+            s_frame_idx = f;
+            s_pending_since_tick = HAL_GetTick();
+        }
+    }
+
+    if (!s_have_pending) return;
+
+    /* Wait for the FPGA peak-power averaging window to complete. */
+    if ((HAL_GetTick() - s_pending_since_tick) < PDC_SETTLE_MS) return;
+
+    uint8_t bytes[PDC_BYTES] = {0};
+    int8_t rc = TCA9548A_Read_Data(PDC_MUX_INDEX, PDC_CHANNEL, PDC_I2C_ADDR,
+                                   PDC_REG, PDC_BYTES, bytes);
+    s_have_pending = false;   /* always consume - don't get stuck on a failing read */
+
+    if (rc != TCA9548A_OK) {
+        s_fail_count++;
+        /* Log sparsely so we don't flood the UART. */
+        if ((s_fail_count & 0x3F) == 1) {
+            printf("pdc_poll: I2C read failed (count=%lu, rc=%d)\r\n",
+                   (unsigned long)s_fail_count, (int)rc);
+        }
+        return;
+    }
+
+    pdc_sample_t sample = {
+        .frame_idx = s_frame_idx,
+        .pdc_raw   = (uint16_t)((uint16_t)bytes[0] | ((uint16_t)bytes[1] << 8)),
+        .flags     = (uint8_t)(s_dark_slot ? PDC_FLAG_DARK_SLOT : 0u),
+    };
+    (void)pdc_buffer_push(&sample);
+}

--- a/Core/Src/pdc_poll.c
+++ b/Core/Src/pdc_poll.c
@@ -1,9 +1,9 @@
 /* Core/Src/pdc_poll.c */
+#include "stm32h7xx_hal.h"
 #include "pdc_poll.h"
 #include "pdc_buffer.h"
 #include "trigger.h"
 #include "tca9548a.h"
-#include "stm32h7xx_hal.h"
 #include <stdbool.h>
 #include <stdio.h>
 

--- a/Core/Src/pdc_poll.c
+++ b/Core/Src/pdc_poll.c
@@ -12,7 +12,9 @@
 #define PDC_I2C_ADDR    0x41
 #define PDC_REG         0x1C
 #define PDC_BYTES       2
-#define PDC_SETTLE_MS   1   /* FPGA averaging window after laser pulse falls */
+#define PDC_SETTLE_MS   2   /* Wait from laser-pulse RISING edge: covers the
+                             * 500 us pulse width + ~hundreds-of-us FPGA
+                             * averaging window with margin. */
 
 static uint32_t s_pending_since_tick = 0;
 static bool     s_have_pending = false;

--- a/Core/Src/trigger.c
+++ b/Core/Src/trigger.c
@@ -23,7 +23,15 @@ volatile uint8_t _safety_trigger_interlock = 0;
 volatile uint32_t fsync_counter = 0;
 volatile uint32_t lsync_counter = 0;
 
-static volatile bool s_current_slot_is_dark = false;
+/* s_current_slot_is_dark is the decision the most recent FSYNC ISR made — it
+ * controls the LASER_TIMER preload that becomes shadow at the next UPDATE
+ * event, i.e. it's the slot for the cycle that runs *after* the cycle that's
+ * about to fire CC1. The cycle that fires CC1 right now uses the shadow that
+ * was loaded by the *previous* FSYNC ISR's preload write. So LSYNC must read
+ * the previous decision, not the current one. We initialize s_prev to true to
+ * match Trigger_Start's direct shadow write of long_lsync_arr. */
+static volatile bool s_current_slot_is_dark = true;
+static volatile bool s_prev_slot_is_dark    = true;
 
 /* SPSC queue of pending PDC samples between the LSYNC ISR (producer) and the
  * main-loop pdc_poll_tick (consumer). Sized for ~200 ms of slack at 40 Hz so
@@ -262,7 +270,9 @@ HAL_StatusTypeDef Trigger_Start() {
 
 	lsync_counter = 1;
 	fsync_counter = 1;
-	s_current_slot_is_dark = false;
+	/* Match initial Trigger_SetConfig direct shadow write of long_lsync_arr. */
+	s_current_slot_is_dark = true;
+	s_prev_slot_is_dark = true;
 	s_pending_head = 0;
 	s_pending_tail = 0;
 	s_pending_count = 0;
@@ -377,6 +387,9 @@ void FSYNC_PeriodElapsedCallback(TIM_HandleTypeDef *htim)
             __HAL_TIM_SET_AUTORELOAD(&LASER_TIMER, short_lsync_arr);
             __HAL_TIM_SET_COMPARE  (&LASER_TIMER, TIM_CHANNEL_1, short_lsync_ccr1);
         }
+        /* Save the slot decision that controls the cycle about to fire — i.e.
+         * the previous ISR's decision — before overwriting with this ISR's. */
+        s_prev_slot_is_dark = s_current_slot_is_dark;
         s_current_slot_is_dark = dark;
     }
 }
@@ -389,12 +402,29 @@ void LSYNC_DelayElapsedCallback(TIM_HandleTypeDef *htim)
      * counter via consume_pdc_pending_overwrites().
      *
      * We enqueue at the rising edge rather than the falling edge because
-     * STM32 TIM_UPDATE events get coalesced when interrupts are delayed —
-     * empirically that caused ~30% sample loss in bursts when other ISRs
-     * (USB, FSYNC) held the CPU. CC1 fires reliably for every frame because
-     * lsync_counter increments correctly under load. The post-pulse FPGA
-     * settle window is handled by pdc_poll_tick's PDC_SETTLE_MS delay. */
+     * STM32 TIM_UPDATE events get coalesced when interrupts are delayed.
+     *
+     * dark_slot is computed locally from lsync_counter rather than read from
+     * s_current_slot_is_dark / s_prev_slot_is_dark — neither was reliable
+     * empirically, because FSYNC ISR for frame N can run either *before* or
+     * *after* LSYNC ISR for cycle N depending on what other ISRs the CPU is
+     * busy with. By computing the slot from lsync_counter directly we get a
+     * deterministic answer that exactly matches what the LASER_TIMER shadow
+     * was during this cycle (which is set by ISR N-1's preload decision = the
+     * decision based on fsync_counter post-incremented to N).
+     *
+     * Cycle K's actual slot:
+     *   cycle 1: initial long (set by Trigger_SetConfig) -> dark
+     *   cycle K>=2: ISR(K-1)'s preload decision, which uses fsync_counter==K:
+     *     dark iff (K < NUM_DARK_FRAMES_AT_START) || (K % skip == 0)
+     * Both branches reduce to the same formula on K = lsync_counter - 1.
+     */
     lsync_counter++;
+    uint32_t cycle = lsync_counter - 1;
+    bool dark = (cycle < NUM_DARK_FRAMES_AT_START)
+             || (trigger_config.LaserPulseSkipInterval > 0
+                 && cycle > 0
+                 && (cycle % trigger_config.LaserPulseSkipInterval) == 0);
 
     if (s_pending_count == PDC_PENDING_CAPACITY) {
         s_pending_tail = (uint16_t)((s_pending_tail + 1) % PDC_PENDING_CAPACITY);
@@ -402,7 +432,7 @@ void LSYNC_DelayElapsedCallback(TIM_HandleTypeDef *htim)
         s_pending_overwrites++;
     }
     s_pending_buf[s_pending_head].frame_idx = lsync_counter;
-    s_pending_buf[s_pending_head].dark_slot = s_current_slot_is_dark;
+    s_pending_buf[s_pending_head].dark_slot = dark;
     s_pending_head = (uint16_t)((s_pending_head + 1) % PDC_PENDING_CAPACITY);
     s_pending_count++;
 }

--- a/Core/Src/trigger.c
+++ b/Core/Src/trigger.c
@@ -28,7 +28,7 @@ static volatile bool s_current_slot_is_dark = false;
 /* SPSC queue of pending PDC samples between the LSYNC ISR (producer) and the
  * main-loop pdc_poll_tick (consumer). Sized for ~200 ms of slack at 40 Hz so
  * brief main-loop stalls (USB bursts, comms handling) don't lose frames. */
-#define PDC_PENDING_CAPACITY 8
+#define PDC_PENDING_CAPACITY 32
 typedef struct {
     uint32_t frame_idx;
     bool     dark_slot;
@@ -382,22 +382,20 @@ void FSYNC_PeriodElapsedCallback(TIM_HandleTypeDef *htim)
 }
 void LSYNC_DelayElapsedCallback(TIM_HandleTypeDef *htim)
 {
+    /* Fires on laser-pulse rising edge (CC1 compare match).  Increment the
+     * frame counter and enqueue (frame_idx, dark_slot) for pdc_poll_tick to
+     * consume from the main loop.  Drop-oldest on overflow so the freshest
+     * samples win; the overwrite count propagates to the ring buffer's drop
+     * counter via consume_pdc_pending_overwrites().
+     *
+     * We enqueue at the rising edge rather than the falling edge because
+     * STM32 TIM_UPDATE events get coalesced when interrupts are delayed —
+     * empirically that caused ~30% sample loss in bursts when other ISRs
+     * (USB, FSYNC) held the CPU. CC1 fires reliably for every frame because
+     * lsync_counter increments correctly under load. The post-pulse FPGA
+     * settle window is handled by pdc_poll_tick's PDC_SETTLE_MS delay. */
     lsync_counter++;
 
-#if 0
-    if (lsync_counter % 200 == 0) {
-    	printf("LSYNC tick: %lu\r\n", lsync_counter);
-    }
-#endif
-
-}
-
-void LSYNC_PeriodElapsedCallback(TIM_HandleTypeDef *htim)
-{
-    /* Fires on laser-pulse falling edge.  Enqueue (frame_idx, dark_slot) for
-     * pdc_poll_tick to consume from the main loop.  Drop-oldest on overflow so
-     * the freshest samples win; the overwrite count propagates to the ring
-     * buffer's drop counter. */
     if (s_pending_count == PDC_PENDING_CAPACITY) {
         s_pending_tail = (uint16_t)((s_pending_tail + 1) % PDC_PENDING_CAPACITY);
         s_pending_count--;
@@ -407,6 +405,15 @@ void LSYNC_PeriodElapsedCallback(TIM_HandleTypeDef *htim)
     s_pending_buf[s_pending_head].dark_slot = s_current_slot_is_dark;
     s_pending_head = (uint16_t)((s_pending_head + 1) % PDC_PENDING_CAPACITY);
     s_pending_count++;
+}
+
+void LSYNC_PeriodElapsedCallback(TIM_HandleTypeDef *htim)
+{
+    /* No-op. PDC sample enqueue moved to LSYNC_DelayElapsedCallback (rising
+     * edge) to avoid TIM_UPDATE coalescing. Kept declared so the dispatch in
+     * main.c still compiles; the dispatch could be removed once we're sure
+     * the rising-edge approach is stable. */
+    (void)htim;
 }
 
 bool get_current_slot_is_dark(void) { return s_current_slot_is_dark; }

--- a/Core/Src/trigger.c
+++ b/Core/Src/trigger.c
@@ -23,6 +23,13 @@ volatile uint8_t _safety_trigger_interlock = 0;
 volatile uint32_t fsync_counter = 0;
 volatile uint32_t lsync_counter = 0;
 
+static volatile bool s_current_slot_is_dark = false;
+
+/* Set by LSYNC_PeriodElapsedCallback; consumed by pdc_poll_tick() from main loop. */
+static volatile bool     s_pdc_sample_pending = false;
+static volatile bool     s_pdc_sample_dark    = false;
+static volatile uint32_t s_pdc_sample_frame   = 0;
+
 uint32_t short_lsync_arr = 0;
 uint32_t long_lsync_arr = 0;
 uint32_t short_lsync_ccr1 = 0;
@@ -246,8 +253,12 @@ HAL_StatusTypeDef Trigger_Start() {
 
 	lsync_counter = 1;
 	fsync_counter = 1;
+	s_current_slot_is_dark = false;
+	s_pdc_sample_pending = false;
 
 	__HAL_TIM_ENABLE_IT(&LASER_TIMER, TIM_IT_CC1);
+	__HAL_TIM_CLEAR_FLAG(&LASER_TIMER, TIM_FLAG_UPDATE);
+	__HAL_TIM_ENABLE_IT(&LASER_TIMER, TIM_IT_UPDATE);
 	if(HAL_TIM_OC_Start_IT(&FSYNC_TIMER, FSYNC_TIMER_CHAN) != HAL_OK) {
         return HAL_ERROR; // Handle error
 	}
@@ -266,6 +277,7 @@ HAL_StatusTypeDef Trigger_Stop() {
     }
 
     __HAL_TIM_DISABLE(&LASER_TIMER);
+    __HAL_TIM_DISABLE_IT(&LASER_TIMER, TIM_IT_UPDATE);
 
 	HAL_GPIO_WritePin(enSyncOUT_GPIO_Port, enSyncOUT_Pin, GPIO_PIN_SET); // disable fsync output
 	HAL_GPIO_WritePin(nTRIG_GPIO_Port, nTRIG_Pin, GPIO_PIN_SET); // disable TA Trigger to fpga
@@ -344,16 +356,16 @@ void FSYNC_PeriodElapsedCallback(TIM_HandleTypeDef *htim)
 {
     fsync_counter++;
     if (trigger_config.LaserPulseSkipInterval > 0) {
-
-		if ((fsync_counter % trigger_config.LaserPulseSkipInterval) == 0 || (fsync_counter < NUM_DARK_FRAMES_AT_START )) {
-            __HAL_TIM_SET_AUTORELOAD(&LASER_TIMER, long_lsync_arr); // next period will be longer by 1 ms
-            __HAL_TIM_SET_COMPARE (&LASER_TIMER, TIM_CHANNEL_1, long_lsync_ccr1);
-            // printf("Long LSYNC\r\n");
+        bool dark = ((fsync_counter % trigger_config.LaserPulseSkipInterval) == 0)
+                    || (fsync_counter < NUM_DARK_FRAMES_AT_START);
+        if (dark) {
+            __HAL_TIM_SET_AUTORELOAD(&LASER_TIMER, long_lsync_arr);
+            __HAL_TIM_SET_COMPARE  (&LASER_TIMER, TIM_CHANNEL_1, long_lsync_ccr1);
         } else {
-            __HAL_TIM_SET_AUTORELOAD(&LASER_TIMER, short_lsync_arr); // next period will be longer by 1 ms
-            __HAL_TIM_SET_COMPARE (&LASER_TIMER, TIM_CHANNEL_1, short_lsync_ccr1);
-            // printf("Short LSYNC\r\n");
+            __HAL_TIM_SET_AUTORELOAD(&LASER_TIMER, short_lsync_arr);
+            __HAL_TIM_SET_COMPARE  (&LASER_TIMER, TIM_CHANNEL_1, short_lsync_ccr1);
         }
+        s_current_slot_is_dark = dark;
     }
 }
 void LSYNC_DelayElapsedCallback(TIM_HandleTypeDef *htim)
@@ -366,4 +378,28 @@ void LSYNC_DelayElapsedCallback(TIM_HandleTypeDef *htim)
     }
 #endif
 
+}
+
+void LSYNC_PeriodElapsedCallback(TIM_HandleTypeDef *htim)
+{
+    /* Fires on laser-pulse falling edge.  Snapshot lsync_counter + slot bit
+     * for pdc_poll to consume from the main loop. */
+    s_pdc_sample_frame  = lsync_counter;
+    s_pdc_sample_dark   = s_current_slot_is_dark;
+    s_pdc_sample_pending = true;
+}
+
+bool get_current_slot_is_dark(void) { return s_current_slot_is_dark; }
+
+bool consume_pdc_sample_pending(bool *out_dark_slot, uint32_t *out_frame_idx)
+{
+    __disable_irq();
+    bool pending = s_pdc_sample_pending;
+    if (pending) {
+        *out_dark_slot = s_pdc_sample_dark;
+        *out_frame_idx = s_pdc_sample_frame;
+        s_pdc_sample_pending = false;
+    }
+    __enable_irq();
+    return pending;
 }

--- a/Core/Src/trigger.c
+++ b/Core/Src/trigger.c
@@ -25,10 +25,19 @@ volatile uint32_t lsync_counter = 0;
 
 static volatile bool s_current_slot_is_dark = false;
 
-/* Set by LSYNC_PeriodElapsedCallback; consumed by pdc_poll_tick() from main loop. */
-static volatile bool     s_pdc_sample_pending = false;
-static volatile bool     s_pdc_sample_dark    = false;
-static volatile uint32_t s_pdc_sample_frame   = 0;
+/* SPSC queue of pending PDC samples between the LSYNC ISR (producer) and the
+ * main-loop pdc_poll_tick (consumer). Sized for ~200 ms of slack at 40 Hz so
+ * brief main-loop stalls (USB bursts, comms handling) don't lose frames. */
+#define PDC_PENDING_CAPACITY 8
+typedef struct {
+    uint32_t frame_idx;
+    bool     dark_slot;
+} pdc_pending_t;
+static volatile pdc_pending_t s_pending_buf[PDC_PENDING_CAPACITY];
+static volatile uint16_t s_pending_head     = 0;  /* write idx (ISR) */
+static volatile uint16_t s_pending_tail     = 0;  /* read idx (main) */
+static volatile uint16_t s_pending_count    = 0;
+static volatile uint16_t s_pending_overwrites = 0;  /* drops-on-full since last consume */
 
 uint32_t short_lsync_arr = 0;
 uint32_t long_lsync_arr = 0;
@@ -254,7 +263,10 @@ HAL_StatusTypeDef Trigger_Start() {
 	lsync_counter = 1;
 	fsync_counter = 1;
 	s_current_slot_is_dark = false;
-	s_pdc_sample_pending = false;
+	s_pending_head = 0;
+	s_pending_tail = 0;
+	s_pending_count = 0;
+	s_pending_overwrites = 0;
 
 	__HAL_TIM_ENABLE_IT(&LASER_TIMER, TIM_IT_CC1);
 	__HAL_TIM_CLEAR_FLAG(&LASER_TIMER, TIM_FLAG_UPDATE);
@@ -382,11 +394,19 @@ void LSYNC_DelayElapsedCallback(TIM_HandleTypeDef *htim)
 
 void LSYNC_PeriodElapsedCallback(TIM_HandleTypeDef *htim)
 {
-    /* Fires on laser-pulse falling edge.  Snapshot lsync_counter + slot bit
-     * for pdc_poll to consume from the main loop. */
-    s_pdc_sample_frame  = lsync_counter;
-    s_pdc_sample_dark   = s_current_slot_is_dark;
-    s_pdc_sample_pending = true;
+    /* Fires on laser-pulse falling edge.  Enqueue (frame_idx, dark_slot) for
+     * pdc_poll_tick to consume from the main loop.  Drop-oldest on overflow so
+     * the freshest samples win; the overwrite count propagates to the ring
+     * buffer's drop counter. */
+    if (s_pending_count == PDC_PENDING_CAPACITY) {
+        s_pending_tail = (uint16_t)((s_pending_tail + 1) % PDC_PENDING_CAPACITY);
+        s_pending_count--;
+        s_pending_overwrites++;
+    }
+    s_pending_buf[s_pending_head].frame_idx = lsync_counter;
+    s_pending_buf[s_pending_head].dark_slot = s_current_slot_is_dark;
+    s_pending_head = (uint16_t)((s_pending_head + 1) % PDC_PENDING_CAPACITY);
+    s_pending_count++;
 }
 
 bool get_current_slot_is_dark(void) { return s_current_slot_is_dark; }
@@ -394,12 +414,22 @@ bool get_current_slot_is_dark(void) { return s_current_slot_is_dark; }
 bool consume_pdc_sample_pending(bool *out_dark_slot, uint32_t *out_frame_idx)
 {
     __disable_irq();
-    bool pending = s_pdc_sample_pending;
+    bool pending = (s_pending_count > 0);
     if (pending) {
-        *out_dark_slot = s_pdc_sample_dark;
-        *out_frame_idx = s_pdc_sample_frame;
-        s_pdc_sample_pending = false;
+        *out_dark_slot = s_pending_buf[s_pending_tail].dark_slot;
+        *out_frame_idx = s_pending_buf[s_pending_tail].frame_idx;
+        s_pending_tail = (uint16_t)((s_pending_tail + 1) % PDC_PENDING_CAPACITY);
+        s_pending_count--;
     }
     __enable_irq();
     return pending;
+}
+
+uint16_t consume_pdc_pending_overwrites(void)
+{
+    __disable_irq();
+    uint16_t n = s_pending_overwrites;
+    s_pending_overwrites = 0;
+    __enable_irq();
+    return n;
 }

--- a/host_tests/Makefile
+++ b/host_tests/Makefile
@@ -1,0 +1,11 @@
+CC ?= gcc
+CFLAGS ?= -Wall -Wextra -Wno-unused-parameter -O0 -g -I../Core/Inc
+
+test_pdc_buffer: test_pdc_buffer.c ../Core/Src/pdc_buffer.c
+	$(CC) $(CFLAGS) -o $@ $<
+
+run: test_pdc_buffer
+	./test_pdc_buffer
+
+clean:
+	rm -f test_pdc_buffer

--- a/host_tests/README.md
+++ b/host_tests/README.md
@@ -1,0 +1,21 @@
+# Host tests
+
+Standalone GCC-built unit tests for pure-C modules in `Core/Src/` that have no STM32 HAL dependencies. Run on a host machine (Linux, macOS, or Windows with MSYS2/MinGW/LLVM installed):
+
+    cd host_tests
+    make run
+
+Expected output for each test:
+
+    <module> host tests OK
+
+These tests are not part of the firmware CMake build. They are a fast sanity check for the pure-data-structure modules; on-hardware verification (full firmware build + bench scan) is still required and is covered by the integration tasks in the corresponding implementation plan.
+
+## Requirements
+
+- gcc, clang, or any host C compiler reachable as `gcc`, `cc`, or via `make CC=...`
+- GNU Make (or compatible)
+
+## Why not part of CMake?
+
+The firmware CMake project uses the ARM cross-compiler (`arm-none-eabi-gcc`), which cannot produce host-runnable binaries. The host tests need a separate, much simpler build path.

--- a/host_tests/test_pdc_buffer.c
+++ b/host_tests/test_pdc_buffer.c
@@ -1,0 +1,53 @@
+#include <assert.h>
+#include <stdio.h>
+#include "../Core/Inc/pdc_buffer.h"
+/* pull in the source directly for the host build */
+#include "../Core/Src/pdc_buffer.c"
+
+static pdc_sample_t mk(uint32_t f) { pdc_sample_t s = { f, (uint16_t)(f & 0xFFFF), 0 }; return s; }
+
+int main(void) {
+    pdc_buffer_reset();
+    assert(pdc_buffer_count() == 0);
+
+    /* push 3, drain 3 */
+    pdc_sample_t s1 = mk(1), s2 = mk(2), s3 = mk(3);
+    assert(!pdc_buffer_push(&s1));
+    assert(!pdc_buffer_push(&s2));
+    assert(!pdc_buffer_push(&s3));
+    assert(pdc_buffer_count() == 3);
+
+    pdc_sample_t out[8];
+    size_t n = pdc_buffer_drain(out, 8);
+    assert(n == 3);
+    assert(out[0].frame_idx == 1 && out[1].frame_idx == 2 && out[2].frame_idx == 3);
+    assert(pdc_buffer_dropped_since_last_drain() == 0);
+
+    /* overflow: push 260, capacity 256, drain should see frames 5..260 (256 samples), drop count 4 */
+    pdc_buffer_reset();
+    for (uint32_t i = 1; i <= 260; i++) {
+        pdc_sample_t s = mk(i);
+        pdc_buffer_push(&s);
+    }
+    assert(pdc_buffer_count() == PDC_BUFFER_CAPACITY);
+    pdc_sample_t big[PDC_BUFFER_CAPACITY];
+    n = pdc_buffer_drain(big, PDC_BUFFER_CAPACITY);
+    assert(n == PDC_BUFFER_CAPACITY);
+    assert(big[0].frame_idx == 5);    /* oldest dropped: 1..4 */
+    assert(big[255].frame_idx == 260);
+    assert(pdc_buffer_dropped_since_last_drain() == 4);
+
+    /* second drain after read: dropped counter resets to 0 */
+    assert(pdc_buffer_dropped_since_last_drain() == 0);
+
+    /* partial drain */
+    pdc_buffer_reset();
+    for (uint32_t i = 1; i <= 10; i++) { pdc_sample_t s = mk(i); pdc_buffer_push(&s); }
+    n = pdc_buffer_drain(out, 4);
+    assert(n == 4);
+    assert(out[0].frame_idx == 1 && out[3].frame_idx == 4);
+    assert(pdc_buffer_count() == 6);
+
+    printf("pdc_buffer host tests OK\n");
+    return 0;
+}


### PR DESCRIPTION
## Summary

Captures one photodiode-current (PDC) value per camera frame at 40 Hz from the safety FPGA, buffers them in SRAM with a frame index + dark-slot bit, and exposes them to the host via a new UART opcode. Hardware-verified end-to-end (see openmotion-sdk's `data-processing/pdc-investigation/findings.md` Appendix A).

The stream is intended as a **diagnostic / laser-health surveillance channel only** — NOT a BFI/BVI correction input. See the SDK investigation doc for why amplitude scaling is the wrong correction.

## Changes

- **New module** `pdc_buffer.{h,c}` — 256-entry ring buffer of `pdc_sample_t = {u32 frame_idx, u16 pdc_raw, u8 flags}` with drop-oldest on overflow and a monotonic drop counter. Host-testable; mini test under `host_tests/`.
- **New module** `pdc_poll.{h,c}` — main-loop driver that consumes pending samples from a SPSC queue (producer = LSYNC ISR, consumer = main loop), waits ~1 ms for the safety FPGA's averaging window, reads `0x41` reg `0x1C/0x1D` over mux 1 ch 7, and pushes a sample to the ring buffer.
- **`Core/Src/trigger.c`** — adds a SPSC queue between LSYNC ISR and `pdc_poll_tick`, enqueues `(frame_idx, dark_slot)` on the laser-pulse rising edge (CC1), computes `dark_slot` locally from `lsync_counter` to avoid an FSYNC/LSYNC ordering off-by-one.
- **New opcode** `OW_CTRL_GET_PDC_BUFFER = 0x25` — drains up to 64 samples per call. Response layout: `[dropped:u16 LE][count:u8][count × 7-byte tuples]`. Documented in `CommandHandling.md`.
- **Build** — `pdc_buffer.c` and `pdc_poll.c` added to `CMakeLists.txt` source list.

## Hardware verification

- 10-minute bench scan, 24,005 PDC samples at 40 Hz, **0 drops, 0 gaps**.
- `dark_slot` aligns with the science pipeline's predicted dark-frame schedule (10, 601, 1201, …) on all post-warmup frames.
- Per-frame PDC vs pedestal-subtracted image mean: Pearson r = 0.74–0.90 across all 16 cameras under stable bench conditions.

Full writeup: `openmotion-sdk` branch `feature/per-frame-pdc`, file `data-processing/pdc-investigation/findings.md` (Appendix A).

## Iteration history

Three on-bench fixes were made during testing and are included here:

1. **SPSC queue** between LSYNC ISR and main loop (was: single-slot pending flag; lost samples on main-loop stalls).
2. **Move enqueue from `TIM_UPDATE` (falling edge) to `CC1` (rising edge)** — STM32 update-event coalescing was dropping ~30 % of samples on a busy CPU.
3. **Compute `dark_slot` locally in LSYNC ISR** from `lsync_counter` — the FSYNC/LSYNC ISR ordering is not deterministic on this STM32H7 setup, so reading `s_current_slot_is_dark` directly was off-by-one.

## Test plan

- [ ] Build verifies cleanly (already validated locally)
- [ ] Flash a unit; run a short scan; confirm telemetry CSV contains `frame_idx`, `dark_slot`, `pdc_dropped_delta` columns and `pdc` values look reasonable
- [ ] Run `scripts/check_dark_slot_consistency.py` from openmotion-sdk against a 30+ s scan CSV; expect 0 science-critical mismatches

## Paired SDK work

Lives on `openmotion-sdk` branch `feature/per-frame-pdc`. Should land together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)