### PR TITLE
fix(trigger): zero-init boot trigger config to stop cold-boot half-rate laser

### DIFF
--- a/Core/Src/main.c
+++ b/Core/Src/main.c
@@ -468,8 +468,10 @@ int main(void)
 
   trigger_init();
   
-  // config trigger timers
-  Trigger_Config_t triggerSetup;
+  // config trigger timers; zero-init so unassigned fields (e.g.
+  // LaserPulseSkipDelayUsec) don't inherit stack garbage — a nonzero skip
+  // delay inflates the long LSYNC slot and halves the laser rate at boot
+  Trigger_Config_t triggerSetup = {0};
   triggerSetup.frequencyHz = 40.0f;
   triggerSetup.triggerPulseWidthUsec = 1000;
   triggerSetup.laserPulseDelayUsec = 250;


### PR DESCRIPTION
## Problem

`main()` builds the boot-time trigger config on the stack and assigns every field except `LaserPulseSkipDelayUsec`, which carries stack garbage into the global `trigger_config`. A nonzero value inflates `long_lsync_arr` in `Trigger_SetConfig` past the 25 ms frame period, so **the laser fires at half the configured rate on cold boot** until the host sends `OW_CTRL_SET_TRIG`.

Observed on hardware running 1.5.4-rc.1-40-g25ffcc5: boot readback showed `LaserPulseSkipDelayUsec: 134309316` (0x08016E44 — stack garbage), FSYNC 40.4 Hz but LSYNC only 20.8 Hz. Writing an explicit 0 over UART restored 40 Hz, confirming the mechanism. The bug exists on `main` too — earlier builds only behaved because their stack garbage happened to be zero.

## Fix

Zero-initialize the struct (`Trigger_Config_t triggerSetup = {0};`) so unassigned fields — including any added in the future — default to 0.

## Verification (on console hardware)

- Flashed this build over DFU; with **no** SET_TRIG sent, boot readback shows `LaserPulseSkipDelayUsec: 0`
- Cold-boot trigger run: FSYNC 40.4 Hz, LSYNC 40.8 Hz — full rate
- Odometers unaffected (laser pulse count matches pre-flash persisted value exactly)
- Release build links clean, zero warnings; cppcheck (CI flags) and lizard pass locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)
